### PR TITLE
option 및 검색어별 search url로 검색 기능 구현

### DIFF
--- a/src/app/(afterLogin)/@modal/(.)[username]/status/[id]/photo/[photoId]/_component/PhotoPost.tsx
+++ b/src/app/(afterLogin)/@modal/(.)[username]/status/[id]/photo/[photoId]/_component/PhotoPost.tsx
@@ -14,8 +14,7 @@ export default function PhotoPost({ post }: { post: IPost }) {
   const createdAt = new Date(post.createdAt);
   const hour = createdAt.getHours();
   const minute = createdAt.getMinutes();
-  console.log("hour : ", hour);
-  console.log("createdAt : ", createdAt);
+
   const router = useRouter();
   const onClickArticle = () => {
     router.push(`/${post.user.id}/status/${post.postId}`);

--- a/src/app/(afterLogin)/@modal/(.)[username]/status/[id]/photo/[photoId]/page.tsx
+++ b/src/app/(afterLogin)/@modal/(.)[username]/status/[id]/photo/[photoId]/page.tsx
@@ -15,7 +15,7 @@ type Props = {
 export default async function PhotoModal({ params }: Props) {
   // id는 postId
   const { username, id, photoId } = params;
-  console.log("modal params:", params);
+
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["post", username, id],

--- a/src/app/(afterLogin)/@modal/default.tsx
+++ b/src/app/(afterLogin)/@modal/default.tsx
@@ -1,5 +1,0 @@
-// catch-all segment가 있어서 더 이상 필요가 없어짐
-
-export default function Modal() {
-  return null;
-}

--- a/src/app/(afterLogin)/[username]/page.tsx
+++ b/src/app/(afterLogin)/[username]/page.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export default async function Username({ params }: Props) {
   const { username } = params;
-  console.log("params", params);
+
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["user", username],

--- a/src/app/(afterLogin)/[username]/status/[id]/_component/PostComments.tsx
+++ b/src/app/(afterLogin)/[username]/status/[id]/_component/PostComments.tsx
@@ -13,8 +13,7 @@ export default function PostComments({ params }: Props) {
   const queryClient = useQueryClient();
   const postData = queryClient.getQueryData<IPost>(["post", params.username, params.id]);
   const { data } = useQuery<IPost[], Object, IPost[], [_1: string, _2: string, _3: string]>({ queryKey: ["post", "comments", params.id], queryFn: getPostComments, enabled: !!postData });
-  console.log("에에에ㅔㅂㅂ");
-  console.log("포포폿", postData);
+
   if (!data || data?.length === 0) return null;
 
   return (

--- a/src/app/(afterLogin)/_component/PostImages.tsx
+++ b/src/app/(afterLogin)/_component/PostImages.tsx
@@ -84,7 +84,7 @@ export default function PostImages({ post }: { post: IPost }) {
 
 const ImageContainer = styled.div`
   box-sizing: border-box;
-  width: 500px;
+  width: 502px;
   height: 502px;
   position: relative;
   margin-top: 12px;

--- a/src/app/(afterLogin)/_component/SearchBar.tsx
+++ b/src/app/(afterLogin)/_component/SearchBar.tsx
@@ -16,6 +16,7 @@ export default function SearchBar() {
   const router = useRouter();
   const onSubmitForm: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
+    localStorage.setItem("searchTabMenu", "hot");
     router.push(`/search?q=${input}&src=typed_query`);
   };
 
@@ -32,16 +33,6 @@ export default function SearchBar() {
     </InnerContainer>
   );
 }
-
-const Container = styled.div`
-  display: flex;
-
-  justify-content: start;
-  width: 350px;
-  height: 53px;
-  box-sizing: border-box;
-  margin-bottom: 20px;
-`;
 
 const InnerContainer = styled.div`
   display: flex;

--- a/src/app/(afterLogin)/_component/Trend.tsx
+++ b/src/app/(afterLogin)/_component/Trend.tsx
@@ -6,7 +6,7 @@ import { trend as ITrend } from "@/model/Trend";
 
 export default function Trend({ trend }: { trend: ITrend }) {
   return (
-    <TrendContainer href={`/search?q=${trend.title}`}>
+    <TrendContainer href={`/search?q=${trend.title}&src=trend_click&vertical=trends`}>
       <div>
         only for X
         <div>

--- a/src/app/(afterLogin)/search/_component/SearchFilter.tsx
+++ b/src/app/(afterLogin)/search/_component/SearchFilter.tsx
@@ -1,12 +1,36 @@
 "use client";
 
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { ChangeEventHandler } from "react";
+
 import styled from "styled-components";
-import { usePathname } from "next/navigation";
 
 export default function SearchFilter() {
   const pathname = usePathname();
-
+  const searchParams = useSearchParams();
   if (pathname !== "/search") return null;
+
+  const router = useRouter();
+  const onChangeFollowers: ChangeEventHandler<HTMLInputElement> = (e) => {
+    router.replace(`/search?${searchParams.toString()}&pf=${e.target.value}`);
+  };
+
+  const onChangeEveryone: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const params = new URLSearchParams(searchParams);
+    if (searchParams.has("pf")) params.delete("pf");
+    router.replace(`/search?${params.toString()}`);
+  };
+
+  const onChangeAnywhere: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const params = new URLSearchParams(searchParams);
+    if (searchParams.has("lf")) params.delete("lf");
+    router.replace(`search?${params.toString()}`);
+  };
+
+  const onChangeNearby: ChangeEventHandler<HTMLInputElement> = (e) => {
+    router.replace(`search?${searchParams.toString()}&lf=${e.target.value}`);
+  };
+
   return (
     <Container>
       <div>
@@ -18,13 +42,13 @@ export default function SearchFilter() {
           <label htmlFor="everyone">
             <InputWrapper>
               <div>모든 사용자</div>
-              <input type="radio" id="everyone" name="user" value="1" defaultChecked></input>
+              <input type="radio" id="everyone" name="user" value="1" onChange={onChangeEveryone} defaultChecked></input>
             </InputWrapper>
           </label>
           <label htmlFor="followers">
             <InputWrapper>
               <div>내가 팔로우하는 사람들</div>
-              <input type="radio" id="followers" name="user" value="on"></input>
+              <input type="radio" id="followers" name="user" value="on" onChange={onChangeFollowers}></input>
             </InputWrapper>
           </label>
         </fieldset>
@@ -33,13 +57,13 @@ export default function SearchFilter() {
           <label htmlFor="anywhere">
             <InputWrapper>
               <div>어디에서나</div>
-              <input type="radio" id="anywhere" name="location" value="2" defaultChecked></input>
+              <input type="radio" id="anywhere" name="location" value="2" onChange={onChangeAnywhere} defaultChecked></input>
             </InputWrapper>
           </label>
           <label htmlFor="curLocal">
             <InputWrapper>
               <div>현 위치 주변</div>
-              <input type="radio" id="curLocal" name="location" value="3"></input>
+              <input type="radio" id="curLocal" name="location" value="on" onChange={onChangeNearby}></input>
             </InputWrapper>
           </label>
         </fieldset>

--- a/src/app/(afterLogin)/search/_component/SearchPostDisplay.tsx
+++ b/src/app/(afterLogin)/search/_component/SearchPostDisplay.tsx
@@ -12,14 +12,10 @@ type Props = {
 };
 
 export default function SearchPostDisplay({ searchParams }: Props) {
-  //   console.log(searchParams);
-
   const { data } = useQuery<IPost[], Object, IPost[], [_1: string, _2: string, searchParams: { q: string; pf?: string; f?: string }]>({
     queryKey: ["posts", "search", searchParams],
     queryFn: getSearchResults,
   });
-  console.log("in searchbar", data);
-  //   return null;
 
   return (
     <>

--- a/src/app/(afterLogin)/search/_component/Tab.tsx
+++ b/src/app/(afterLogin)/search/_component/Tab.tsx
@@ -1,33 +1,51 @@
 "use client";
 
 import styled from "styled-components";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 
 export default function SearchTab() {
   const [selectedMenu, setSelectedMenu] = useState("hot");
 
   const searchParams = useSearchParams();
+
   const router = useRouter();
+
+  const checkSearchParams = () => {
+    let params = new URLSearchParams(searchParams);
+    params.delete("f");
+    if (selectedMenu === "hot") router.replace(`/search?${params.toString()}`);
+    else router.replace(`/search?${params.toString()}&f=${selectedMenu}`);
+  };
+
+  useEffect(() => {
+    const tabMenu = localStorage.getItem("searchTabMenu");
+    setSelectedMenu(tabMenu!);
+  }, [searchParams.values()]);
+
+  useEffect(() => {
+    checkSearchParams();
+  }, [selectedMenu]);
+
   const handleHotClicked = () => {
     setSelectedMenu("hot");
-    router.replace(`/search?q=${searchParams.get("q")}&src=typed_query`);
+    localStorage.setItem("searchTabMenu", "hot");
   };
   const handleNewClicked = () => {
     setSelectedMenu("new");
-    router.replace(`/search?q=${searchParams.get("q")}&src=typed_query&f=live`);
+    localStorage.setItem("searchTabMenu", "new");
   };
   const handleUserClicked = () => {
     setSelectedMenu("user");
-    router.replace(`/search?q=${searchParams.get("q")}&src=typed_query&f=user`);
+    localStorage.setItem("searchTabMenu", "user");
   };
   const handleMediaClicked = () => {
     setSelectedMenu("media");
-    router.replace(`/search?q=${searchParams.get("q")}&src=typed_query&f=media`);
+    localStorage.setItem("searchTabMenu", "media");
   };
   const handleListClicked = () => {
     setSelectedMenu("list");
-    router.replace(`/search?q=${searchParams.get("q")}&src=typed_query&f=list`);
+    localStorage.setItem("searchTabMenu", "list");
   };
 
   return (

--- a/src/app/(afterLogin)/search/_lib/getSearchResults.ts
+++ b/src/app/(afterLogin)/search/_lib/getSearchResults.ts
@@ -4,7 +4,7 @@ import { QueryFunction } from "@tanstack/query-core";
 import { IPost } from "@/model/Post";
 
 type Props = {
-  searchParams: string;
+  searchParams: { q: string; f?: string; pf?: string };
 };
 
 // queryKey type?
@@ -12,8 +12,10 @@ const getSearchResult: QueryFunction<IPost[], [_1: string, _2: string, searchPar
   //   console.log("queryKey", queryKey);
   const [_1, _2, searchParams] = queryKey;
   //   console.log("q?", searchParams.q);
-  const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/api/search/q=${searchParams.q}`);
-  console.log(response);
+
+  const params = new URLSearchParams(searchParams);
+  const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/api/search?${params.toString()}`);
+
   if (response.statusText === "OK") return response.data;
 };
 

--- a/src/app/(afterLogin)/search/page.tsx
+++ b/src/app/(afterLogin)/search/page.tsx
@@ -1,92 +1,42 @@
-"use client";
-
-import { useQuery } from "@tanstack/react-query";
-import Image from "next/image";
-
-import styled from "styled-components";
-
-import getSearchResults from "../search/_lib/getSearchResults";
-
-import { useSearchParams } from "next/navigation";
-
+import { QueryClient, HydrationBoundary, dehydrate } from "@tanstack/react-query";
 import SearchBar from "../_component/SearchBar";
 import BackBtn from "../_component/BackBtn";
 import Tab from "./_component/Tab";
 import SearchPostDisplay from "./_component/SearchPostDisplay";
+import { Container, TabContainer, SearchContainer, SearchWrapper, TabFixedContainer } from "./style";
+import getSearchResult from "./_lib/getSearchResults";
 
 type Props = { searchParams: { q: string; f?: string; pf?: string } };
 
 // 이거 왜 매개변수 이름이 searchParams?
+// 서버 컴포넌트에서 제공하는 기능.
+// client component에서는 useSearchParams등의 훅을 사용해야함.
 export default function Search({ searchParams }: Props) {
-  console.log("searchParams", searchParams);
+  // console.log("searchParams!", searchParams);
   // const q = searchParams.get("q");
-  // console.log("qqqqqq", q);
 
+  const queryClient = new QueryClient();
+  queryClient.prefetchQuery({
+    queryKey: ["posts", "search", searchParams],
+    queryFn: getSearchResult,
+  });
   return (
     <Container>
-      <TabContainer>
-        <TabFixedContainer>
-          <SearchContainer>
-            <BackBtn></BackBtn>
-            <SearchWrapper>
-              <SearchBar></SearchBar>
-            </SearchWrapper>
-          </SearchContainer>
-          <Tab />
-        </TabFixedContainer>
-      </TabContainer>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <TabContainer>
+          <TabFixedContainer>
+            <SearchContainer>
+              <BackBtn></BackBtn>
+              <SearchWrapper>
+                <SearchBar></SearchBar>
+              </SearchWrapper>
+            </SearchContainer>
+            <Tab />
+          </TabFixedContainer>
+        </TabContainer>
 
-      <SearchPostDisplay searchParams={searchParams} />
+        <SearchPostDisplay searchParams={searchParams} />
+      </HydrationBoundary>
     </Container>
   );
 }
-
-const Container = styled.main`
-  box-sizing: border-box;
-
-  display: flex;
-  flex-direction: column;
-
-  height: 1000dvh;
-  width: inherit;
-`;
-
-const TabContainer = styled.div`
-  box-sizing: border-box;
-  border-top: 0px;
-  width: 598px;
-  height: 115px;
-  /* height: auto; */
-
-  /* display: flex; */
-`;
-
-const TabFixedContainer = styled.div`
-  box-sizing: border-box;
-  border-bottom: 1px solid rgb(239, 243, 244);
-
-  position: fixed;
-
-  width: inherit;
-  height: inherit;
-  z-index: 1;
-  background-color: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(12px);
-`;
-
-const SearchContainer = styled.div`
-  box-sizing: border-box;
-  padding: 0 16px;
-  display: flex;
-  width: inherit;
-  height: 60px;
-`;
-
-const SearchWrapper = styled.div`
-  box-sizing: border-box;
-  flex-grow: 1;
-  max-width: 510px;
-  width: 510px;
-  height: 53px;
-  display: flex;
-`;

--- a/src/app/(afterLogin)/search/style.ts
+++ b/src/app/(afterLogin)/search/style.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import styled from "styled-components";
+
+export const Container = styled.main`
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: column;
+  width: inherit;
+`;
+
+export const TabContainer = styled.div`
+  box-sizing: border-box;
+  border-top: 0px;
+  width: 598px;
+  height: 115px;
+  /* height: auto; */
+
+  /* display: flex; */
+`;
+
+export const TabFixedContainer = styled.div`
+  box-sizing: border-box;
+  border-bottom: 1px solid rgb(239, 243, 244);
+
+  position: fixed;
+
+  width: inherit;
+  height: inherit;
+  z-index: 1;
+  background-color: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+`;
+
+export const SearchContainer = styled.div`
+  box-sizing: border-box;
+  padding: 0 16px;
+  display: flex;
+  width: inherit;
+  height: 60px;
+`;
+
+export const SearchWrapper = styled.div`
+  box-sizing: border-box;
+  flex-grow: 1;
+  max-width: 510px;
+  width: 510px;
+  height: 53px;
+  display: flex;
+`;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -258,79 +258,386 @@ export const handlers = [
       },
     ]);
   }),
-  http.get("/api/search/:tag", ({ request, params }) => {
-    console.log("request", request);
-    const { tag } = params;
+  http.get("/api/search", ({ request, params }) => {
+    const url = new URL(request.url);
+    const searchParams = url.searchParams;
 
-    return HttpResponse.json([
-      {
-        postId: 1,
-        user: User[0],
-        content: `검색 결과1 ${tag}`,
-        images: [{ imageId: 1, url: faker.image.urlLoremFlickr() }],
-        createdAt: "",
-        comments: [],
-        retweet: 14,
-        likes: 113,
-        watched: 123,
-      },
-      {
-        postId: 2,
-        user: User[1],
-        content: `검색 결과1 ${tag}`,
-        images: [
-          { imageId: 1, url: faker.image.urlLoremFlickr() },
-          { imageId: 2, url: faker.image.urlLoremFlickr() },
-          { imageId: 3, url: faker.image.urlLoremFlickr() },
-          { imageId: 4, url: faker.image.urlLoremFlickr() },
-        ],
-        createdAt: "",
-        comments: [],
-        retweet: 13,
-        likes: 2,
-        watched: 12,
-      },
-      {
-        postId: 3,
-        user: User[2],
-        content: `검색 결과1 ${tag}`,
-        images: [
-          { imageId: 1, url: faker.image.urlLoremFlickr() },
-          { imageId: 2, url: faker.image.urlLoremFlickr() },
-          { imageId: 3, url: faker.image.urlLoremFlickr() },
-        ],
-        createdAt: "",
-        comments: [],
-        retweet: 1300,
-        likes: 15000,
-        watched: 100034,
-      },
-      {
-        postId: 4,
-        user: User[3],
-        content: `검색 결과1 ${tag}`,
-        images: [
-          { imageId: 1, url: faker.image.urlLoremFlickr() },
-          { imageId: 2, url: faker.image.urlLoremFlickr() },
-        ],
-        createdAt: "",
-        comments: [],
-        retweet: 1,
-        likes: 78,
-        watched: 180,
-      },
-      {
-        postId: 5,
-        user: User[4],
-        content: `검색 결과1 ${tag}`,
-        images: [],
-        createdAt: "",
-        comments: [],
-        retweet: 77,
-        likes: 88,
-        watched: 188,
-      },
-    ]);
+    const q: string | null = searchParams.get("q");
+    let pf: string | null = null;
+    let f: string | null = null;
+    let lf: string | null = null;
+
+    if (searchParams.has("pf")) {
+      pf = searchParams.get("pf");
+    }
+    if (searchParams.has("f")) {
+      f = searchParams.get("f");
+    }
+    if (searchParams.has("lf")) {
+      lf = searchParams.get("lf");
+    }
+
+    if (f === "new") {
+      if (pf && lf) {
+        return HttpResponse.json([
+          {
+            postId: 3,
+            user: User[2],
+            content: `검색어 ${q}, 내가 팔로우 하는 사람들 pf : ${pf}, 내위치 주변 lf : ${lf}`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+              { imageId: 3, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1300,
+            likes: 15000,
+            watched: 100034,
+          },
+          {
+            postId: 4,
+            user: User[3],
+            content: `검색어 ${q}, 내가 팔로우 하는 사람들 pf : ${pf}, 내위치 주변 lf : ${lf}`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1,
+            likes: 78,
+            watched: 180,
+          },
+        ]);
+      } else if (pf) {
+        return HttpResponse.json([
+          {
+            postId: 3,
+            user: User[2],
+            content: `검색어 ${q}, 내가 팔로우 하는 사람들 pf : ${pf}`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+              { imageId: 3, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1300,
+            likes: 15000,
+            watched: 100034,
+          },
+          {
+            postId: 4,
+            user: User[3],
+            content: `검색어 ${q}, 내가 팔로우 하는 사람들 pf : ${pf}`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1,
+            likes: 78,
+            watched: 180,
+          },
+        ]);
+      } else if (lf) {
+        return HttpResponse.json([
+          {
+            postId: 3,
+            user: User[2],
+            content: `검색어 ${q}, 내위치 주변 lf : ${lf}`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+              { imageId: 3, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1300,
+            likes: 15000,
+            watched: 100034,
+          },
+          {
+            postId: 4,
+            user: User[3],
+            content: `검색어 ${q}, 내위치 주변 lf : ${lf}`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1,
+            likes: 78,
+            watched: 180,
+          },
+        ]);
+      } else {
+        return HttpResponse.json([
+          {
+            postId: 1,
+            user: User[0],
+            content: `검색어 :  ${q}, 최신포스트 1 f=${f} `,
+            images: [{ imageId: 1, url: faker.image.urlLoremFlickr() }],
+            createdAt: "",
+            comments: [],
+            retweet: 14,
+            likes: 113,
+            watched: 123,
+          },
+          {
+            postId: 2,
+            user: User[1],
+            content: `검색어 :  ${q}, 최신포스트 2 f=${f} `,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+              { imageId: 3, url: faker.image.urlLoremFlickr() },
+              { imageId: 4, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 13,
+            likes: 2,
+            watched: 12,
+          },
+        ]);
+      }
+    } else if (f === "user") {
+      return HttpResponse.json([
+        {
+          postId: 1,
+          user: User[0],
+          content: `검색어 :  ${q}, user포스트 1 f=${f} `,
+          images: [{ imageId: 1, url: faker.image.urlLoremFlickr() }],
+          createdAt: "",
+          comments: [],
+          retweet: 14,
+          likes: 113,
+          watched: 123,
+        },
+        {
+          postId: 2,
+          user: User[1],
+          content: `검색어 :  ${q}, user포스트 2 f=${f} `,
+          images: [
+            { imageId: 1, url: faker.image.urlLoremFlickr() },
+            { imageId: 2, url: faker.image.urlLoremFlickr() },
+            { imageId: 3, url: faker.image.urlLoremFlickr() },
+            { imageId: 4, url: faker.image.urlLoremFlickr() },
+          ],
+          createdAt: "",
+          comments: [],
+          retweet: 13,
+          likes: 2,
+          watched: 12,
+        },
+      ]);
+    } else if (f === "media") {
+      return HttpResponse.json([
+        {
+          postId: 1,
+          user: User[0],
+          content: `검색어 :  ${q}, media 1 f=${f} `,
+          images: [{ imageId: 1, url: faker.image.urlLoremFlickr() }],
+          createdAt: "",
+          comments: [],
+          retweet: 14,
+          likes: 113,
+          watched: 123,
+        },
+        {
+          postId: 2,
+          user: User[1],
+          content: `검색어 :  ${q}, media 2 f=${f} `,
+          images: [
+            { imageId: 1, url: faker.image.urlLoremFlickr() },
+            { imageId: 2, url: faker.image.urlLoremFlickr() },
+            { imageId: 3, url: faker.image.urlLoremFlickr() },
+            { imageId: 4, url: faker.image.urlLoremFlickr() },
+          ],
+          createdAt: "",
+          comments: [],
+          retweet: 13,
+          likes: 2,
+          watched: 12,
+        },
+      ]);
+    } else if (f === "list") {
+      return HttpResponse.json([
+        {
+          postId: 1,
+          user: User[0],
+          content: `검색어 :  ${q}, list 1 f=${f} `,
+          images: [{ imageId: 1, url: faker.image.urlLoremFlickr() }],
+          createdAt: "",
+          comments: [],
+          retweet: 14,
+          likes: 113,
+          watched: 123,
+        },
+        {
+          postId: 2,
+          user: User[1],
+          content: `검색어 :  ${q}, list 2 f=${f} `,
+          images: [
+            { imageId: 1, url: faker.image.urlLoremFlickr() },
+            { imageId: 2, url: faker.image.urlLoremFlickr() },
+            { imageId: 3, url: faker.image.urlLoremFlickr() },
+            { imageId: 4, url: faker.image.urlLoremFlickr() },
+          ],
+          createdAt: "",
+          comments: [],
+          retweet: 13,
+          likes: 2,
+          watched: 12,
+        },
+      ]);
+    } else {
+      if (searchParams.get("src") === "trend_click") {
+        return HttpResponse.json([
+          {
+            postId: 1,
+            user: User[0],
+            content: `검색 결과1 ${q}, trends for you를 통해 검색하셨습니다.`,
+            images: [{ imageId: 1, url: faker.image.urlLoremFlickr() }],
+            createdAt: "",
+            comments: [],
+            retweet: 14,
+            likes: 113,
+            watched: 123,
+          },
+          {
+            postId: 2,
+            user: User[1],
+            content: `검색 결과1 ${q}, trends for you를 통해 검색하셨습니다.`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+              { imageId: 3, url: faker.image.urlLoremFlickr() },
+              { imageId: 4, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 13,
+            likes: 2,
+            watched: 12,
+          },
+          {
+            postId: 3,
+            user: User[2],
+            content: `검색 결과1 ${q}, trends for you를 통해 검색하셨습니다.`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+              { imageId: 3, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1300,
+            likes: 15000,
+            watched: 100034,
+          },
+          {
+            postId: 4,
+            user: User[3],
+            content: `검색 결과1 ${q}, trends for you를 통해 검색하셨습니다.`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1,
+            likes: 78,
+            watched: 180,
+          },
+          {
+            postId: 5,
+            user: User[4],
+            content: `검색 결과1 ${q}, trends for you를 통해 검색하셨습니다.`,
+            images: [],
+            createdAt: "",
+            comments: [],
+            retweet: 77,
+            likes: 88,
+            watched: 188,
+          },
+        ]);
+      } else {
+        return HttpResponse.json([
+          {
+            postId: 1,
+            user: User[0],
+            content: `검색 결과1 ${q}, 검색창로 검색하셨습니다.`,
+            images: [{ imageId: 1, url: faker.image.urlLoremFlickr() }],
+            createdAt: "",
+            comments: [],
+            retweet: 14,
+            likes: 113,
+            watched: 123,
+          },
+          {
+            postId: 2,
+            user: User[1],
+            content: `검색 결과1 ${q}, 검색창로 검색하셨습니다.`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+              { imageId: 3, url: faker.image.urlLoremFlickr() },
+              { imageId: 4, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 13,
+            likes: 2,
+            watched: 12,
+          },
+          {
+            postId: 3,
+            user: User[2],
+            content: `검색 결과1 ${q}, 검색창로 검색하셨습니다.`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+              { imageId: 3, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1300,
+            likes: 15000,
+            watched: 100034,
+          },
+          {
+            postId: 4,
+            user: User[3],
+            content: `검색 결과1 ${q}, 검색창로 검색하셨습니다.`,
+            images: [
+              { imageId: 1, url: faker.image.urlLoremFlickr() },
+              { imageId: 2, url: faker.image.urlLoremFlickr() },
+            ],
+            createdAt: "",
+            comments: [],
+            retweet: 1,
+            likes: 78,
+            watched: 180,
+          },
+          {
+            postId: 5,
+            user: User[4],
+            content: `검색 결과1 ${q}, 검색어로 검색하셨습니다.`,
+            images: [],
+            createdAt: "",
+            comments: [],
+            retweet: 77,
+            likes: 88,
+            watched: 188,
+          },
+        ]);
+      }
+    }
   }),
   http.get("/api/users/:userId/posts", ({ request, params }): StrictResponse<any> => {
     const { userId } = params;


### PR DESCRIPTION
## 주요 내용
+ 검색 옵션에서 '팔로워만', '내 주변' 기능 활성화(mock data로 분기처리 했음)
+ 검색창 입력으로 search 페이지 이동과 trend 클릭으로 search 페이지 이동의 url 분기처리(mock data도 활용)
+ search Tab에서 새로고침시 직전에 보고있던 tab 유지 (localStorage 활용)
+ search 페이지에서 새로운 검색어 입력 시 다시 '인기' tab으로 이동 (localStorage 활용)

## 수정해야할 부분
+ search Tab에서 새로고침 시 직전에 보고 있던 tab 유지할 때 깜박거림이 있음
+ 검색으로 search Page로 이동 후에 검색창에 검색어 유지가 안 됨(상태관리 라이브러리 사용?)